### PR TITLE
add character option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ pseudolocale('This is going to be pseudolocalized %token%.', { extend: 0.3 }); /
 // [!!Ȃ ťēšť ŝťŕĩŉğ ŵĩťħ â %token%.        !!]
 ```
 
+### ExtendCharacter
+
+Specifies the character used to pad the string when extending. Useful when you want the added width to be visible instead of using whitespace.
+
+Default is `' '` (a space).
+
+```js
+pseudolocale('This is going to be pseudolocalized %token%.', {
+  extend: 0.3,
+  extendCharacter: '~',
+}); // 30%
+// [!!~~~~~~Ţĥĩś ĩś ĝōĩńĝ ţō ƀē ƥśēũďōĺōćàĺĩźēď %token%.~~~~~~!!]
+```
+
 ### Override
 
 Specifies an override character that all characters in the string will be replaced with. Used to easily spot unlocalized strings. Set to `undefined` to go back to regular pseudolocalealization.

--- a/src/command.ts
+++ b/src/command.ts
@@ -35,6 +35,10 @@ export function makeProgram(): Command {
       parseFloat,
     )
     .option(
+      '-c, --extendCharacter <char>',
+      "sets the character used for padding when extending (default: ' ')",
+    )
+    .option(
       '-o, --override <char>',
       'replaces all characters with specified character',
     )
@@ -69,6 +73,14 @@ export function makeProgram(): Command {
       console.log('  Extend strings to ensure space for localization');
       console.log("    $ pseudolocale -e 0.3 -s 'test string'");
       console.log('    > ' + pseudolocale('test string', { extend: 0.3 }));
+      console.log('');
+
+      console.log('  Extend strings with a custom character');
+      console.log("    $ pseudolocale -e 0.3 -c '~' -s 'test string'");
+      console.log(
+        '    > ' +
+          pseudolocale('test string', { extend: 0.3, extendCharacter: '~' }),
+      );
       console.log('');
 
       console.log('  Pseudolocalize all strings in a JSON file');

--- a/src/pad.ts
+++ b/src/pad.ts
@@ -1,17 +1,18 @@
 /**
  * Extends the width of the string by the specified percentage.
+ * The character used for padding can be customized (defaults to a space).
  */
-export function pad(str: string, percent: number): string {
+export function pad(str: string, percent: number, character = ' '): string {
   let lengthLeft = Math.floor((str.length * percent) / 2);
   let lengthRight = lengthLeft;
   let paddedString = str;
 
   while (lengthLeft-- > 0) {
-    paddedString = ` ${paddedString}`;
+    paddedString = `${character}${paddedString}`;
   }
 
   while (lengthRight-- > 0) {
-    paddedString = `${paddedString} `;
+    paddedString = `${paddedString}${character}`;
   }
 
   return paddedString;

--- a/src/str.ts
+++ b/src/str.ts
@@ -9,6 +9,7 @@ export type Options = {
   startDelimiter?: string;
   endDelimiter?: string;
   extend?: number;
+  extendCharacter?: string;
   override?: string;
 };
 
@@ -19,6 +20,7 @@ const defaultOptions = {
   startDelimiter: '',
   endDelimiter: '',
   extend: 0,
+  extendCharacter: ' ',
   override: undefined,
 };
 
@@ -80,6 +82,7 @@ export default function str(str: string, customOptions?: Options): string {
     prepend,
     append,
     extend,
+    extendCharacter,
     override,
   } = { ...defaultOptions, ...customOptions };
   const regexTokens = getTokens(str, {
@@ -105,5 +108,5 @@ export default function str(str: string, customOptions?: Options): string {
     result += convertedCharacter || character;
   }
 
-  return prepend + pad(result, extend) + append;
+  return prepend + pad(result, extend, extendCharacter) + append;
 }

--- a/src/test/str.test.ts
+++ b/src/test/str.test.ts
@@ -61,11 +61,21 @@ describe('pseudolocale', () => {
     expect(s1.indexOf('%%this%%')).not.toBe(-1);
   });
 
-  it('should pad the string be the specified pad amount', () => {
+  it('should pad the string be the specified pad amount (with whitespace as default)', () => {
     const options = { extend: 0.2 };
     const s1 = pseudolocale('this is a test string', options);
 
     expect(s1.length).toBe(31);
+    expect(s1.indexOf('~')).toBe(-1);
+  });
+
+  it('should pad with a custom character when extendCharacter is set', () => {
+    const options = { extend: 0.2, extendCharacter: '~' };
+    const s1 = pseudolocale('this is a test string', options);
+
+    expect(s1.length).toBe(31);
+    expect(s1.startsWith('[!!~~')).toBe(true);
+    expect(s1.endsWith('~~!!]')).toBe(true);
   });
 
   it('should support a custom start token', () => {


### PR DESCRIPTION
Add the possibility for a user to chose the character to use for string extension, [as noted in this issue](https://github.com/MartinCerny-awin/pseudolocale/issues/37).